### PR TITLE
use corda-ibc/go/x/ibc/light-clients/xx-corda instead of cosmos-sdk/x/ibc/light-clients/xx-corda

### DIFF
--- a/chains/corda/codec.go
+++ b/chains/corda/codec.go
@@ -3,14 +3,12 @@ package corda
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
-	cordatypes "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda/types"
 	"github.com/datachainlab/relayer/core"
 )
 
 // RegisterInterfaces register the ibc transfer module interfaces to protobuf
 // Any.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	cordatypes.RegisterInterfaces(registry)
 	registry.RegisterImplementations(
 		(*core.ChainConfigI)(nil),
 		&ChainConfig{},

--- a/chains/corda/codec.go
+++ b/chains/corda/codec.go
@@ -3,12 +3,14 @@ package corda
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
+	cordatypes "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda/types"
 	"github.com/datachainlab/relayer/core"
 )
 
 // RegisterInterfaces register the ibc transfer module interfaces to protobuf
 // Any.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+	cordatypes.RegisterInterfaces(registry)
 	registry.RegisterImplementations(
 		(*core.ChainConfigI)(nil),
 		&ChainConfig{},

--- a/chains/corda/create-client.go
+++ b/chains/corda/create-client.go
@@ -6,16 +6,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
-	cordatypes "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/xx-corda/types"
+	cordatypes "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda/types"
 	"github.com/datachainlab/relayer/core"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // MakeMsgCreateClient creates a CreateClientMsg to this chain
 func (c *Chain) MakeMsgCreateClient(clientID string, dstHeader core.HeaderI, signer sdk.AccAddress) (sdk.Msg, error) {
 	// information for building consensus state can be obtained from host state
-	host, err := c.client.hostAndBankQuery.QueryHost(
+	host, err := c.client.hostAndBank.QueryHost(
 		context.TODO(),
-		&cordatypes.QueryHostRequest{},
+		&emptypb.Empty{},
 	)
 	if err != nil {
 		return nil, err

--- a/chains/corda/grpc.go
+++ b/chains/corda/grpc.go
@@ -5,14 +5,14 @@ import (
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/02-client/types"
 	conntypes "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types"
 	chantypes "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types"
-	cordatypes "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/xx-corda/types"
+	cordatypes "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda/types"
 	"google.golang.org/grpc"
 )
 
 type cordaIbcClient struct {
 	conn *grpc.ClientConn
 
-	hostAndBankQuery cordatypes.QueryServiceClient
+	hostAndBank cordatypes.HostAndBankServiceClient
 
 	clientQuery   clienttypes.QueryClient
 	connQuery     conntypes.QueryClient
@@ -34,7 +34,7 @@ func createCordaIbcClient(addr string) (*cordaIbcClient, error) {
 	return &cordaIbcClient{
 		conn: conn,
 
-		hostAndBankQuery: cordatypes.NewQueryServiceClient(conn),
+		hostAndBank: cordatypes.NewHostAndBankServiceClient(conn),
 
 		clientQuery:   clienttypes.NewQueryClient(conn),
 		connQuery:     conntypes.NewQueryClient(conn),

--- a/chains/corda/query.go
+++ b/chains/corda/query.go
@@ -11,8 +11,8 @@ import (
 	conntypes "github.com/cosmos/cosmos-sdk/x/ibc/core/03-connection/types"
 	chantypes "github.com/cosmos/cosmos-sdk/x/ibc/core/04-channel/types"
 	ibcexported "github.com/cosmos/cosmos-sdk/x/ibc/core/exported"
-	cordatypes "github.com/cosmos/cosmos-sdk/x/ibc/light-clients/xx-corda/types"
 	"github.com/datachainlab/relayer/core"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // QueryLatestHeight queries the chain for the latest height and returns it
@@ -73,9 +73,9 @@ func (c *Chain) QueryChannel(height int64, prove bool) (chanRes *chantypes.Query
 func (c *Chain) QueryBalance(address sdk.AccAddress) (sdk.Coins, error) {
 	addr := address.String()
 
-	res, err := c.client.hostAndBankQuery.QueryBank(
+	res, err := c.client.hostAndBank.QueryBank(
 		context.TODO(),
-		&cordatypes.QueryBankRequest{},
+		&emptypb.Empty{},
 	)
 	if err != nil {
 		return nil, err

--- a/chains/fabric/codec.go
+++ b/chains/fabric/codec.go
@@ -3,6 +3,7 @@ package fabric
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
+	"github.com/datachainlab/relayer/chains/corda"
 	"github.com/datachainlab/relayer/core"
 )
 
@@ -18,5 +19,6 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 func makeEncodingConfig() params.EncodingConfig {
 	encodingConfig := core.MakeEncodingConfig()
 	RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	corda.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	return encodingConfig
 }

--- a/chains/fabric/codec.go
+++ b/chains/fabric/codec.go
@@ -3,7 +3,6 @@ package fabric
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simapp/params"
-	"github.com/datachainlab/relayer/chains/corda"
 	"github.com/datachainlab/relayer/core"
 )
 
@@ -19,6 +18,5 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 func makeEncodingConfig() params.EncodingConfig {
 	encodingConfig := core.MakeEncodingConfig()
 	RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	corda.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	return encodingConfig
 }

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 
+	corda "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda"
 	fabric "github.com/datachainlab/fabric-ibc/x/ibc/light-clients/xx-fabric"
 )
 
@@ -46,6 +47,7 @@ var moduleBasics = module.NewBasicManager(
 	slashing.AppModuleBasic{},
 	ibc.AppModuleBasic{},
 	fabric.AppModuleBasic{},
+	corda.AppModuleBasic{},
 	upgrade.AppModuleBasic{},
 	evidence.AppModuleBasic{},
 	transfer.AppModuleBasic{},

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/confio/ics23/go v0.6.3
 	github.com/cosmos/cosmos-sdk v0.40.0-rc3
 	github.com/cosmos/relayer v1.0.0-rc1
+	github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260
 	github.com/datachainlab/fabric-ibc v0.0.0-20210118090849-c2eaee7a3314
 	github.com/gogo/protobuf v1.3.1
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20200416031218-eff2f9306191
@@ -17,11 +18,12 @@ require (
 	github.com/tendermint/tendermint v0.34.0-rc6
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/grpc v1.35.0
+	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/datachainlab/cosmos-sdk v0.34.4-0.20210323140005-7c931c37f43c
+	github.com/cosmos/cosmos-sdk => github.com/datachainlab/cosmos-sdk v0.34.4-0.20210312160443-1cdc372f98d0
 	github.com/go-kit/kit => github.com/go-kit/kit v0.8.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
 	github.com/hyperledger/fabric-sdk-go => github.com/datachainlab/fabric-sdk-go v0.0.0-20200730074927-282a61dcd92e

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/confio/ics23/go v0.6.3
 	github.com/cosmos/cosmos-sdk v0.40.0-rc3
 	github.com/cosmos/relayer v1.0.0-rc1
-	github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260
+	github.com/datachainlab/corda-ibc/go v0.0.0-20210402075556-89ca9bb218b6
 	github.com/datachainlab/fabric-ibc v0.0.0-20210118090849-c2eaee7a3314
 	github.com/gogo/protobuf v1.3.1
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20200416031218-eff2f9306191

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,10 @@ github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe2
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260 h1:iG2T6aXLj9SSNjn3FJMKxmCTGEYok5TdbMV8lEsdnT4=
 github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260/go.mod h1:Uyxr4ZHebUwoCpoiuFBw60nU2aL6a56xVSbtTWpQtQU=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210401130307-17922a3d7a60 h1:FmUcMKd1sOOuWgWRVPTIh8R833Z4qmGvS9HLcvsXfmE=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210401130307-17922a3d7a60/go.mod h1:Uyxr4ZHebUwoCpoiuFBw60nU2aL6a56xVSbtTWpQtQU=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210402075556-89ca9bb218b6 h1:FKziK1AF29XcE37Rh8Yk2GIbRMTlS8BmfztlgIFUi+s=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210402075556-89ca9bb218b6/go.mod h1:gHhvCV/KHwdkZ3uUjBUG+6/8NuMpsM97lQ95eAesn4I=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218080829-0fdbe02ff6db h1:XBVsA1tjPhuNFxToKQOChbmmxxXDyhPWeIWcNjvmw0s=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218080829-0fdbe02ff6db/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218130631-a1df1c6bb307 h1:AUDCD5IPzPiNUULm0H6iHvC8RFhGPjQWD4AHPw93Yaw=

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260 h1:iG2T6aXLj9SSNjn3FJMKxmCTGEYok5TdbMV8lEsdnT4=
+github.com/datachainlab/corda-ibc/go v0.0.0-20210331030043-5d22b56f8260/go.mod h1:Uyxr4ZHebUwoCpoiuFBw60nU2aL6a56xVSbtTWpQtQU=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218080829-0fdbe02ff6db h1:XBVsA1tjPhuNFxToKQOChbmmxxXDyhPWeIWcNjvmw0s=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218080829-0fdbe02ff6db/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218130631-a1df1c6bb307 h1:AUDCD5IPzPiNUULm0H6iHvC8RFhGPjQWD4AHPw93Yaw=
@@ -239,6 +241,8 @@ github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218184724-b562fbf6575b h1:r9Ar
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210218184724-b562fbf6575b/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210311123812-cf6f3ae3f130 h1:co2MXQ4jD8Fgvi0MW4+cb5p4Edz44kKqFTskzPhVl9I=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210311123812-cf6f3ae3f130/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
+github.com/datachainlab/cosmos-sdk v0.34.4-0.20210312160443-1cdc372f98d0 h1:CMysHbRCuebfvRknL5/AnVAdw3hggbLuh1SCOUOd1IQ=
+github.com/datachainlab/cosmos-sdk v0.34.4-0.20210312160443-1cdc372f98d0/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210316123038-7f06bc872f91 h1:yZcWY7WZ4hz+LPakMsraSJuGsvkXMwEzccIALEerr+0=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210316123038-7f06bc872f91/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/datachainlab/cosmos-sdk v0.34.4-0.20210317061320-1db27075f4cb h1:Ob7WhGzsELQsxdYjUnSIBfFcNKbYJ0t+hydX5qLZJzY=


### PR DESCRIPTION
I have moved ClientState/ConsensusState implementations for Corda-IBC from cosmos-sdk to corda-ibc/go.
This PR fixes relayer to use corda-ibc/go.